### PR TITLE
Updated "northeast of Maridia" to "top-left" in a few spots

### DIFF
--- a/Profiles/Default/locations.yml
+++ b/Profiles/Default/locations.yml
@@ -616,21 +616,21 @@
   LocationId: InnerMaridiaWateringHoleLeft
   Name:
     - Text: Watering Hole Left
-    - Text: the left side of the pit with two items in the northeast of Maridia
+    - Text: the left side of the pit with two items in the top-left of Maridia
     - Text: Super Missile (yellow Maridia)
       Weight: 0
 - LocationNumber: 141
   LocationId: InnerMaridiaWateringHoleRight
   Name:
     - Text: Watering Hole Right
-    - Text: the right side of the pit with two items in the northeast of Maridia
+    - Text: the right side of the pit with two items in the top-left of Maridia
     - Text: Missile (yellow Maridia super missile)
       Weight: 0
 - LocationNumber: 142
   LocationId: InnerMaridiaPseudoPlasmaSpark
   Name:
     - Text: Pseudo Plasma Spark Room
-    - Text: the room leading up to the pit with two items in the northeast of Maridia
+    - Text: the room leading up to the pit with two items in the top-left of Maridia
     - Text: Missile (yellow Maridia false wall)
       Weight: 0
 - LocationNumber: 143


### PR DESCRIPTION
Noticed this during Betus's stream on Saturday when he cleared one of the Watering Hole items. I originally changed it to "northwest", but then thought it should be "top-left" because we're side-scrolling. What do you all think?